### PR TITLE
enhance IEmailAttachment to support string, stream, and byte array content

### DIFF
--- a/Southport.Messaging.Email.Core.Test/EmailAddress_UnitTest.cs
+++ b/Southport.Messaging.Email.Core.Test/EmailAddress_UnitTest.cs
@@ -6,10 +6,10 @@ using Xunit.Abstractions;
 
 namespace Southport.Messaging.Email.Core.Test
 {
-    public class EmailAddress_UnitTest
+    public class EmailAddressUnitTest
     {
-        public List<string> ValidEmailAddresses = new List<string>()
-        {
+        public readonly List<string> ValidEmailAddresses =
+        [
             "email@example.com",
             "firstname.lastname@example.com",
             "email@subdomain.example.com",
@@ -23,10 +23,10 @@ namespace Southport.Messaging.Email.Core.Test
             "email@example.museum",
             "email@example.co.jp",
             "firstname-lastname@example.com"
-        };
+        ];
 
-        public List<string> InvalidEmailAddresses = new List<string>()
-        {
+        public readonly List<string> InvalidEmailAddresses =
+        [
             "plainaddress",
             "#@%^%#$@#$@#.com",
             "@example.com",
@@ -42,11 +42,11 @@ namespace Southport.Messaging.Email.Core.Test
             "email@-example.com",
             "email@example..com",
             "Abc..123@example.com"
-        };
+        ];
 
         private readonly  ITestOutputHelper _output;
 
-        public EmailAddress_UnitTest(ITestOutputHelper output)
+        public EmailAddressUnitTest(ITestOutputHelper output)
         {
             _output = output;
         }

--- a/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachment.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachment.cs
@@ -12,21 +12,90 @@
 // <summary></summary>
 // ***********************************************************************
 
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
 namespace Southport.Messaging.Email.Core.EmailAttachments
 {
     /// <summary>
     /// Class EmailAttachment.
     /// Implements the <see cref="Southport.Messaging.Email.Core.EmailAttachments.IEmailAttachment" />
-    /// Implements the <see cref="Southport.Messaging.Email.Core.EmailAttachments.IEmailAttachment" />
     /// </summary>
     /// <seealso cref="Southport.Messaging.Email.Core.EmailAttachments.IEmailAttachment" />
-    public class EmailAttachment : IEmailAttachment
+    public class EmailAttachment : IEmailAttachment, IAsyncDisposable
     {
+        private string _contentString;
+
         /// <summary>
-        /// Gets or sets the content.
+        ///  Gets or sets the string content. Only set 1 of ContentString, StreamContent, or ContentBytes.
         /// </summary>
-        /// <value>The content.</value>
-        public string Content { get; set; }
+
+        public string ContentString
+        {
+            get => _contentString;
+            set
+            {
+                if (_contentStream != null || _contentBytes != null)
+                {
+                    throw new InvalidOperationException("Only one of ContentString, ContentStream, or ContentBytes can be set.");
+                }
+                _contentString = value;
+            }
+        }
+        
+        private Stream _contentStream;
+
+        /// <summary>
+        /// Gets or sets the stream content. Only set 1 of ContentString, StreamContent, or ContentBytes.
+        /// </summary>
+        public Stream ContentStream
+        {
+            get => _contentStream;
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(_contentString) || _contentBytes != null)
+                {
+                    throw new InvalidOperationException(
+                        "Only one of ContentString, ContentStream, or ContentBytes can be set.");
+                }
+
+                // dispose any previous owned stream
+                _contentStream?.Dispose();
+                _contentStream = null;
+
+                if (value == null)
+                {
+                    _contentStream?.Dispose();
+                    _contentStream = null;
+                    return;
+                }
+
+                if (!value.CanRead) throw new InvalidOperationException("Stream must be readable to copy.");
+                var ms = new MemoryStream();
+                if (value.CanSeek) value.Position = 0;
+                value.CopyTo(ms);
+                ms.Position = 0;
+                _contentStream = ms;
+            }
+        }
+        
+        private byte[] _contentBytes;
+        /// <summary>
+        /// Gets or sets the byte array content. Only set 1 of ContentString, StreamContent, or ContentBytes.
+        /// </summary>
+        public byte[] ContentBytes {
+            get => _contentBytes;
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(_contentString) || _contentStream != null)
+                {
+                    throw new InvalidOperationException("Only one of ContentString, ContentStream, or ContentBytes can be set.");
+                }
+                _contentBytes = value;
+            }
+        }
+
         /// <summary>
         /// Gets or sets the type of the attachment.
         /// </summary>
@@ -37,5 +106,17 @@ namespace Southport.Messaging.Email.Core.EmailAttachments
         /// </summary>
         /// <value>The attachment filename.</value>
         public string AttachmentFilename { get; set; }
+
+        public void Dispose()
+        {
+            _contentStream?.Dispose();
+            ContentStream?.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_contentStream != null) await _contentStream.DisposeAsync();
+            if (ContentStream != null) await ContentStream.DisposeAsync();
+        }
     }
 }

--- a/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentBytes.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentBytes.cs
@@ -1,0 +1,11 @@
+﻿namespace Southport.Messaging.Email.Core.EmailAttachments;
+
+public sealed class EmailAttachmentBytes : EmailAttachmentBase
+{
+    public EmailAttachmentBytes(byte[] bytes, string fileName, string contentType)
+    {
+        ContentBytes = bytes;
+        AttachmentFilename = fileName;
+        AttachmentType = contentType;
+    }
+}

--- a/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentStream.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentStream.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Southport.Messaging.Email.Core.EmailAttachments;
+
+public sealed class EmailAttachmentStream : EmailAttachmentBase, IAsyncDisposable
+    {
+        /// <summary>
+        /// Create a stream attachment.
+        /// - copyOnSet: if true, the input stream will be copied into a MemoryStream (attachment owns the copy).
+        /// - takeOwnershipWhenNotCopying: if true and copyOnSet is false, the attachment will dispose the provided stream when disposed.
+        /// </summary>
+        private readonly bool _copyOnSet;
+        private readonly bool _takeOwnershipWhenNotCopying;
+
+        /// <summary>
+        /// Create a stream attachment.
+        /// - copyOnSet: if true, the input stream will be copied into a MemoryStream (attachment owns the copy).
+        /// - takeOwnershipWhenNotCopying: if true and copyOnSet is false, the attachment will dispose the provided stream when disposed.
+        /// </summary>
+        public EmailAttachmentStream(bool copyOnSet = true, bool takeOwnershipWhenNotCopying = false)
+        {
+            _copyOnSet = copyOnSet;
+            _takeOwnershipWhenNotCopying = takeOwnershipWhenNotCopying;
+        }
+
+        public EmailAttachmentStream(Stream stream, string filename = null, string contentType = null, bool copyOnSet = true, bool takeOwnershipWhenNotCopying = false)
+            : this(copyOnSet, takeOwnershipWhenNotCopying)
+        {
+            AttachmentFilename = filename;
+            AttachmentType = contentType;
+            ContentStream = stream;
+        }
+
+        public override Stream ContentStream
+        {
+            get => _contentStream;
+            set
+            {
+                if (value != null && (_contentString != null || _contentBytes != null))
+                    throw new InvalidOperationException("Only one of ContentString, ContentStream, or ContentBytes can be set.");
+
+                // Dispose any previously owned stream
+                if (_contentStream != null && _ownsStream)
+                {
+                    _contentStream.Dispose();
+                    _contentStream = null;
+                    _ownsStream = false;
+                }
+
+                if (value == null)
+                {
+                    _contentStream = null;
+                    _ownsStream = false;
+                    return;
+                }
+
+                if (_copyOnSet)
+                {
+                    if (!value.CanRead) throw new InvalidOperationException("Stream must be readable to copy.");
+                    var ms = new MemoryStream();
+                    if (value.CanSeek) value.Position = 0;
+                    value.CopyTo(ms);
+                    ms.Position = 0;
+                    _contentStream = ms;
+                    _ownsStream = true;
+                }
+                else
+                {
+                    _contentStream = value;
+                    _ownsStream = _takeOwnershipWhenNotCopying;
+                }
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_contentStream != null) await _contentStream.DisposeAsync();
+            if (ContentStream != null) await ContentStream.DisposeAsync();
+        }
+    }

--- a/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentString.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/EmailAttachmentString.cs
@@ -1,0 +1,13 @@
+﻿
+namespace Southport.Messaging.Email.Core.EmailAttachments
+{
+    public sealed class StringAttachment : EmailAttachmentBase
+    {
+        public StringAttachment(string content, string filename = null, string contentType = "text/plain")
+        {
+            ContentString = content;
+            AttachmentFilename = filename;
+            AttachmentType = contentType;
+        }
+    }
+}

--- a/Southport.Messaging.Email.Core/EmailAttachments/IEmailAttachment.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/IEmailAttachment.cs
@@ -12,18 +12,32 @@
 // <summary></summary>
 // ***********************************************************************
 
+using System;
+using System.IO;
+using System.Net.Http;
+
 namespace Southport.Messaging.Email.Core.EmailAttachments
 {
     /// <summary>
     /// Interface IEmailAttachment
     /// </summary>
-    public interface IEmailAttachment
+    public interface IEmailAttachment : IDisposable
     {
         /// <summary>
-        /// Gets or sets the content.
+        /// Gets or sets the string content. Only set 1 of ContentString, StreamContent, or ContentBytes.
         /// </summary>
-        /// <value>The content.</value>
-        string Content { get; set; }
+        string ContentString { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the stream content. Only set 1 of ContentString, StreamContent, or ContentBytes.
+        /// </summary>
+        Stream ContentStream { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the content bytes. Only set 1 of ContentString, StreamContent
+        /// </summary>
+        byte[] ContentBytes { get; set; }
+        
         /// <summary>
         /// Gets or sets the type of the attachment.
         /// </summary>

--- a/Southport.Messaging.Email.Core/EmailAttachments/IEmailAttachment.cs
+++ b/Southport.Messaging.Email.Core/EmailAttachments/IEmailAttachment.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.IO;
-using System.Net.Http;
 
 namespace Southport.Messaging.Email.Core.EmailAttachments
 {

--- a/Southport.Messaging.Email.Core/IEmailMessageCore.cs
+++ b/Southport.Messaging.Email.Core/IEmailMessageCore.cs
@@ -24,7 +24,7 @@ namespace Southport.Messaging.Email.Core
     /// <summary>
     /// Interface IEmailMessageCore
     /// </summary>
-    public interface IEmailMessageCore : IDisposable
+    public interface IEmailMessageCore : IAsyncDisposable
     {
         #region Properties
 

--- a/Southport.Messaging.Email.Core/IEmailMessageCore.cs
+++ b/Southport.Messaging.Email.Core/IEmailMessageCore.cs
@@ -24,7 +24,7 @@ namespace Southport.Messaging.Email.Core
     /// <summary>
     /// Interface IEmailMessageCore
     /// </summary>
-    public interface IEmailMessageCore
+    public interface IEmailMessageCore : IDisposable
     {
         #region Properties
 

--- a/Southport.Messaging.Email.Core/Southport.Messaging.Email.Core.csproj
+++ b/Southport.Messaging.Email.Core/Southport.Messaging.Email.Core.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <RepositoryType>GIT</RepositoryType>
     <PackageTags>Email</PackageTags>
-    <PackageReleaseNotes>NET 10.0 Upgrade.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added stream and byte array content to attachments.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## **CodeAnt-AI Description**
**Support string, stream, and byte[] email attachments with ownership and proper disposal**

### What Changed
- Attachments can now carry content as a string, a byte array, or a stream; only one content source may be set at a time.
- Stream attachments can be configured to copy the input into an internal memory stream (so the attachment owns a copy) or to use the provided stream and optionally take ownership; assigning a non-readable stream when a copy is requested now throws.
- Attachment implementations and the email message core expose disposal so owned streams are disposed (sync and async), preventing open stream leaks.
- Added concrete attachment types for bytes, strings, and streams and updated package release notes.

### Impact
`✅ Easier creation of attachments from strings, bytes, or streams`
`✅ Fewer leaked streams when sending emails`
`✅ Clearer errors when multiple content sources are set`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
